### PR TITLE
feat: refactor authentication handlers and update password recovery flow

### DIFF
--- a/src/features/auth/hooks/use-auth-operations.ts
+++ b/src/features/auth/hooks/use-auth-operations.ts
@@ -53,11 +53,11 @@ export function useAuthOperations() {
     }
   };
 
-  const emailGenderHandler = async (data: EmailGender) => {
+  const forgotPasswordHandler = async (data: EmailGender) => {
     try {
-      const res = await authDatasource.emailGender(data);
+      const res = await authDatasource.forgotPassword(data);
       toast.success(res);
-      router.push("/login");
+      toast.info("Revisa tu correo electrónico para continuar");
     } catch (error) {
       console.error(error);
     }
@@ -73,20 +73,23 @@ export function useAuthOperations() {
     }
   };
 
-  const recoveryPasswordHandler = async (
+  const resetPasswordHandler = async (
     data: Omit<Recovery, "resetPasswordToken">
   ) => {
     try {
-      const token = searchParams.get("reset_password_token");
+      const token = searchParams.get("token");
       if (!token) {
-        toast.error("El token de reseteo no ha sido probehido");
+        toast.error("Token inválido o no proporcionado");
         return;
       }
-      const res = await AuthService.getInstance().recoveryPassword({
+      const res = await authDatasource.resetPassword({
         ...data,
         resetPasswordToken: token,
       });
       toast.success(res);
+      setTimeout(() => {
+        router.push("/login");
+      }, 1500);
     } catch (error) {
       console.error(error);
     }
@@ -95,8 +98,8 @@ export function useAuthOperations() {
   return {
     loginHandler,
     registerHandler,
-    emailGenderHandler,
+    forgotPasswordHandler,
     logoutHandler,
-    recoveryPasswordHandler,
+    resetPasswordHandler,
   };
 }

--- a/src/features/auth/hooks/use-email-gender-form.ts
+++ b/src/features/auth/hooks/use-email-gender-form.ts
@@ -15,7 +15,7 @@ const schema = z.object({
 type FormFields = z.infer<typeof schema>;
 
 export function useEmailGenderForm() {
-  const { emailGenderHandler } = useAuthOperations();
+  const { forgotPasswordHandler } = useAuthOperations();
   const methods = useForm<FormFields>({
     resolver: zodResolver(schema),
     defaultValues: {
@@ -24,7 +24,7 @@ export function useEmailGenderForm() {
   });
 
   const onSubmit: SubmitHandler<FormFields> = async (data) => {
-    await emailGenderHandler(data);
+    await forgotPasswordHandler(data);
   };
 
   return { onSubmit, methods, isSubmiting: methods.formState.isSubmitting };

--- a/src/features/auth/hooks/use-recovery-form.ts
+++ b/src/features/auth/hooks/use-recovery-form.ts
@@ -7,7 +7,13 @@ import { useAuthOperations } from "./use-auth-operations";
 
 const schema = z
   .object({
-    password: z.string().min(1, "La contraseña es requerida"),
+    password: z
+      .string()
+      .min(8, "La contraseña debe tener como mínimo 8 carácteres")
+      .regex(
+        /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&.])[A-Za-z\d@$!%*?&.]{8,}$/,
+        "La contraseña debe contener al menos una letra mayúscula, una letra minúscula, un número y un símbolo especial"
+      ),
     passwordConfirmation: z
       .string()
       .min(1, "La contraseña de confirmación es requerida"),
@@ -20,7 +26,7 @@ const schema = z
 type FormFields = z.infer<typeof schema>;
 
 export function useRecoveryForm() {
-  const { recoveryPasswordHandler } = useAuthOperations();
+  const { resetPasswordHandler } = useAuthOperations();
   const methods = useForm<FormFields>({
     resolver: zodResolver(schema),
     defaultValues: {
@@ -30,7 +36,7 @@ export function useRecoveryForm() {
   });
 
   const onSubmit: SubmitHandler<FormFields> = async (data) => {
-    await recoveryPasswordHandler(data);
+    await resetPasswordHandler(data);
   };
 
   return { onSubmit, methods, isSubmiting: methods.formState.isSubmitting };

--- a/src/features/auth/presentation/components/recovery-form.tsx
+++ b/src/features/auth/presentation/components/recovery-form.tsx
@@ -36,7 +36,7 @@ const RecoveryForm = () => {
               Inicia sesión
             </Link>
             <Button disabled={isSubmiting} type="submit">
-              {isSubmiting ? <LoadingSpinner /> : "Enviar email"}
+              {isSubmiting ? <LoadingSpinner /> : "Restablecer contraseña"}
             </Button>
           </div>
         </form>

--- a/src/features/auth/services/auth.datasource.ts
+++ b/src/features/auth/services/auth.datasource.ts
@@ -7,8 +7,8 @@ interface IAuthService {
   login(user: Login): Promise<AuthResponse>;
   register(user: Register): Promise<AuthResponse>;
   logout(): Promise<void>;
-  emailGender(email: EmailGender): Promise<string>;
-  recoveryPassword(user: Recovery): Promise<string>;
+  forgotPassword(email: EmailGender): Promise<string>;
+  resetPassword(user: Recovery): Promise<string>;
 }
 
 export class AuthService implements IAuthService {
@@ -20,17 +20,22 @@ export class AuthService implements IAuthService {
     this.axiosCLient = AxiosClient.getInstance();
   }
 
-  async recoveryPassword(user: Recovery): Promise<string> {
-    const { data } = await this.axiosCLient.put(`${this.url}/password`, {
-      user,
-    });
+  async forgotPassword(email: EmailGender): Promise<string> {
+    const { data } = await this.axiosCLient.post<{ message: string }>(
+      `${this.url}/forgot-password`,
+      email
+    );
     return data.message;
   }
 
-  async emailGender(email: EmailGender): Promise<string> {
-    const { data } = await this.axiosCLient.post(`${this.url}/password`, {
-      user: email,
-    });
+  async resetPassword(recovery: Recovery): Promise<string> {
+    const { data } = await this.axiosCLient.post<{ message: string }>(
+      `${this.url}/reset-password`,
+      {
+        token: recovery.resetPasswordToken,
+        password: recovery.password,
+      }
+    );
     return data.message;
   }
 


### PR DESCRIPTION
- Renamed `emailGenderHandler` to `forgotPasswordHandler` and updated its implementation to send a forgot password request.
- Renamed `recoveryPasswordHandler` to `resetPasswordHandler` and modified it to handle password reset requests with token validation.
- Updated form hooks to reflect the new handler names and adjusted validation messages for better user feedback.
- Changed button text in the recovery form to "Restablecer contraseña" for clarity.